### PR TITLE
PP-92/Dockerization and Testnet configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 #dist/
 .idea/
 package-lock.json
+environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ USER node
 WORKDIR /srv/app
 COPY --from=compiler --chown=node:node /usr/src/app/node_modules ./node_modules/
 COPY --chown=node:node package*.json ./
-COPY --chown=node:node server-config.json ./
+COPY --chown=node:node server-config*.json ./
 COPY --chown=node:node dist ./dist/
 COPY --chown=node:node scripts ./scripts/
 #RUN chmod -R 777 ./dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm i --cache /tmp/1
 COPY . ./
 # Runtime container
 FROM node:12-alpine
-RUN apk add --no-cache bash curl
+RUN apk add --no-cache bash
 RUN mkdir -p /srv/app && chown node:node /srv/app \
  && mkdir -p /srv/data && chown node:node /srv/data
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,4 @@ COPY --chown=node:node package*.json ./
 COPY --chown=node:node server-config*.json ./
 COPY --chown=node:node dist ./dist/
 COPY --chown=node:node scripts ./scripts/
-#RUN chmod -R 777 ./dist/
-#RUN npm run register -- --account="0xa975D1DE6d7dA3140E9e293509337373402558bE" --mnemonic="'digital unknown jealous mother legal hedgehog save glory december universe spread figure custom found six'"
 EXPOSE 8090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,25 +4,13 @@ services:
   rif-relay:
     build:
       context: .
-    entrypoint: sh -c 'node dist/commands/Start.js --config server-config.json'
+    entrypoint: sh -c 'node dist/commands/Start.js --config server-config.testnet.json'
     ports:
       - "8090:8090"
-        #depends_on: 
-        #- 'rif-relay-contracts'
     volumes:
-          - /home/user/workspace/enveloping/environment:/srv/app/environment
-          - /home/user/workspace/enveloping/environment/manager:/srv/app/environment/manager
-          - /home/user/workspace/enveloping/environment/workers:/srv/app/environment/workers
+      - "./environment:/srv/app/environment"
     networks:
       - rif-relay
-  
-        #relaying-services:
-        #build:
-        #context: ./relaying-services-sdk-dapp       
-        #dockerfile: Dockerfile      
-        #entrypoint: sh -c 'npm run start'
-        #depends_on:
-        #    - rif-relay
 
 networks:
   rif-relay:

--- a/server-config.testnet.json
+++ b/server-config.testnet.json
@@ -1,0 +1,13 @@
+{
+    "url": "http://localhost:8090",
+    "port": 8090,
+    "relayHubAddress": "0x66Fa9FEAfB8Db66Fe2160ca7aEAc7FC24e254387",
+    "relayVerifierAddress": "0x56ccdB6D312307Db7A4847c3Ea8Ce2449e9B79e9",
+    "deployVerifierAddress": "0x5C6e96a84271AC19974C3e99d6c4bE4318BfE483",
+    "gasPriceFactor": 1,
+    "rskNodeUrl": "http://172.17.0.1:4444",
+    "devMode": true,
+    "customReplenish": false,
+    "logLevel": 1,
+    "workdir": "/srv/app/environment"
+}


### PR DESCRIPTION
## What

- Add Testnet configuration
- Remove commented lines
- Remove `curl` from the runtime containers

## Why

- We need to dockerize the relay server app to be used on Testnet

## Refs

- https://rsklabs.atlassian.net/browse/PP-95
